### PR TITLE
Remove Basic support plan; rename Gold to Standard and Platinum to Premium

### DIFF
--- a/pkg/server/eula.go
+++ b/pkg/server/eula.go
@@ -36,9 +36,8 @@ const (
 )
 
 const (
-	SupportPlanBasic    = "basic"
-	SupportPlanGold     = "gold"
-	SupportPlanPlatinum = "platinum"
+	SupportPlanStandard = "standard"
+	SupportPlanPremium  = "premium"
 )
 
 type EULAInfo struct {
@@ -87,8 +86,8 @@ func (form *EULAInfo) Complete() error {
 }
 
 func (form EULAInfo) Validate() error {
-	if form.PaymentTerm == PaymentTermPAYG && form.SupportPlan == SupportPlanPlatinum {
-		return errors.New("support plan Platinum is not offered with PAYG contract")
+	if form.PaymentTerm == PaymentTermPAYG && form.SupportPlan == SupportPlanPremium {
+		return errors.New("support plan Premium is not offered with PAYG contract")
 	}
 	return nil
 }
@@ -101,23 +100,15 @@ type EULATemplateKey struct {
 var eulaTemplates = map[EULATemplateKey]string{
 	{
 		PaymentTerm: "annual",
-		SupportPlan: "basic",
-	}: "1QBIjMA-hqfnm5H879Y9zSLGufVeQrHD3cLO0mVQNxPo",
-	{
-		PaymentTerm: "annual",
-		SupportPlan: "gold",
+		SupportPlan: "standard",
 	}: "16LawcDIbeNNIGJeS0pKmXYFukMQMw0olqL5gVWlmD3c",
 	{
 		PaymentTerm: "annual",
-		SupportPlan: "platinum",
+		SupportPlan: "premium",
 	}: "1bcMuWQBdDT8I4XMAdHyyYJSMjlEHjxuIWclvvF5vajQ",
 	{
 		PaymentTerm: "payg",
-		SupportPlan: "basic",
-	}: "16LB_aBLWn44MMn5gDyOTL7cehLpvsQAtVO71gDVY3Gs",
-	{
-		PaymentTerm: "payg",
-		SupportPlan: "gold",
+		SupportPlan: "standard",
 	}: "10_tM2wUTxWRKhyGIOLWK1TuZ2ivRFdCM69iRFU5FgNI",
 }
 

--- a/pkg/server/mail_quotation.go
+++ b/pkg/server/mail_quotation.go
@@ -38,7 +38,7 @@ Thanks for your interest in licensing {{.Offer}}.
 
 2. {{.Offer}} {{.Plan}} comes with a 30 day free trial. So, you don't need to purchase a license for ephemeral Kubernetes clusters (typically found in Dev or CI/CD environments).
 
-3. The various support options are detailed in the attached quotation. We offer a Basic support level for free with our {{.Plan}} license. For SLA bound tickets, we charge extra and offer Gold / Platinum plans.
+3. The various support options are detailed in the attached quotation. We offer Standard and Premium support plans with our {{.Plan}} license.
 
 If you have any questions or concerns, please do not hesitate to contact us. If you have any technical questions, someone from our product team will get back to you.
 

--- a/templates/eula.html
+++ b/templates/eula.html
@@ -110,14 +110,11 @@
                 <div class="control">
                   <div class="select">
                     <select id="support-plan" name="support-plan">
-                      <option value="basic">
-                        Basic
+                      <option value="standard">
+                        Standard
                       </option>
-                      <option value="gold">
-                        Gold
-                      </option>
-                      <option value="platinum">
-                        Platinum
+                      <option value="premium">
+                        Premium
                       </option>
                     </select>
                   </div>

--- a/templates/kubedb_inquiry.html
+++ b/templates/kubedb_inquiry.html
@@ -302,8 +302,8 @@
                       <div class="select is-fullwidth">
                         <select name="support-plan">
                           <option value="">-- Select Plan --</option>
-                          <option value="Standard">Standard</option>
-                          <option value="Platinum">Platinum</option>
+                          <option value="Standard">Standard (9x5)</option>
+                          <option value="Platinum">Premium (24x7)</option>
                         </select>
                       </div>
                     </div>


### PR DESCRIPTION
- Remove Basic support option
- Rename Gold → Standard
- Rename Platinum → Premium

Signed-off-by: Tamal Saha <tamal@appscode.com>