### PR TITLE
Render sales emails in markdown format

### DIFF
--- a/pkg/server/mail_deal_registration.go
+++ b/pkg/server/mail_deal_registration.go
@@ -20,23 +20,60 @@ import (
 	"fmt"
 
 	"gomodules.xyz/mailer"
-	"sigs.k8s.io/yaml"
 )
 
 func NewDealRegistrationMailer(info *DealRegistrationInfo) mailer.Mailer {
-	data, err := yaml.Marshal(info)
-	if err != nil {
-		data = []byte("Error: " + err.Error()) // nolint:goconst
-	}
-
 	src := fmt.Sprintf(`Hi,
 A new deal has been registered with the following details:
 
-%s
+## Partner
+- Name: %s
+- Email: %s
+- Company: %s
+- Region: %s
+
+## Customer
+- Name: %s
+- Email: %s
+- Company: %s
+- Phone: %s
+- Address: %s
+- Country: %s
+
+## Deal
+- Product: %s
+- Kubernetes Setup: %s
+- Estimated Deal Size: %s
+- Estimated Database Memory: %s
+- Estimated Kubernetes Nodes: %s
+- Estimated Kubernetes Clusters: %s
+- Project Timeline: %s
+- Competitor Product: %s
+- Notes: %s
 
 Regards,
 Deal Registration System
-`, string(data))
+`,
+		info.PartnerName,
+		info.PartnerEmail,
+		info.PartnerCompany,
+		info.Region,
+		info.CustomerName,
+		info.CustomerEmail,
+		info.CustomerCompany,
+		info.CustomerPhone,
+		info.CustomerAddress,
+		info.CustomerCountry,
+		info.Product,
+		info.KubernetesSetup,
+		info.EstimatedDealSize,
+		info.EstimatedDatabaseMemory,
+		info.EstimatedKubernetesNodes,
+		info.EstimatedKubernetesClusters,
+		info.ProjectTimeline,
+		info.CompetitorProduct,
+		info.Notes,
+	)
 	return mailer.Mailer{
 		Sender:          MailSales,
 		BCC:             "",

--- a/pkg/server/mail_kubedb_inquiry.go
+++ b/pkg/server/mail_kubedb_inquiry.go
@@ -20,23 +20,44 @@ import (
 	"fmt"
 
 	"gomodules.xyz/mailer"
-	"sigs.k8s.io/yaml"
 )
 
 func NewKubeDBInquiryMailer(info *KubeDBInquiryInfo) mailer.Mailer {
-	data, err := yaml.Marshal(info)
-	if err != nil {
-		data = []byte("Error: " + err.Error())
-	}
-
 	src := fmt.Sprintf(`Hi,
 A new KubeDB inquiry has been submitted with the following details:
 
-%s
+## Customer
+- Name: %s
+- Email: %s
+- Company: %s
+- Phone: %s
+- Address: %s
+- Country: %s
+
+## Inquiry
+- Estimated Database Memory: %s
+- Kubernetes Setup: %s
+- Support Plan: %s
+- Project Timeline: %s
+- Professional Services: %s
+- Notes: %s
 
 Regards,
 KubeDB Inquiry System
-`, string(data))
+`,
+		info.CustomerName,
+		info.CustomerEmail,
+		info.CustomerCompany,
+		info.CustomerPhone,
+		info.CustomerAddress,
+		info.CustomerCountry,
+		info.EstimatedDatabaseMemory,
+		info.KubernetesSetup,
+		info.SupportPlan,
+		info.ProjectTimeline,
+		info.ProfessionalServices,
+		info.Notes,
+	)
 	return mailer.Mailer{
 		Sender:          MailSales,
 		BCC:             "",

--- a/pkg/server/mail_kubedb_sales_qa.go
+++ b/pkg/server/mail_kubedb_sales_qa.go
@@ -17,26 +17,91 @@ limitations under the License.
 package server
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"gomodules.xyz/mailer"
-	"sigs.k8s.io/yaml"
 )
 
+type salesQANote struct {
+	Section  int    `json:"section"`
+	Question int    `json:"question"`
+	Prompt   string `json:"prompt"`
+	Signal   string `json:"signal"`
+	Note     string `json:"note"`
+}
+
 func NewKubeDBSalesQAMailer(info *KubeDBSalesQAInfo) mailer.Mailer {
-	data, err := yaml.Marshal(info)
-	if err != nil {
-		data = []byte("Error: " + err.Error())
+	notesMarkdown := "- No notes were submitted."
+	if info.NotesJSON != "" {
+		var notes []salesQANote
+		if err := json.Unmarshal([]byte(info.NotesJSON), &notes); err != nil {
+			notesMarkdown = fmt.Sprintf("- Failed to parse notes JSON: %v", err)
+		} else if len(notes) > 0 {
+			var b strings.Builder
+			for _, n := range notes {
+				line := fmt.Sprintf("- S%dQ%d", n.Section, n.Question)
+				if n.Signal != "" {
+					line += fmt.Sprintf(" (%s)", strings.ToUpper(n.Signal))
+				}
+				if n.Prompt != "" {
+					line += fmt.Sprintf(": %s", n.Prompt)
+				}
+				b.WriteString(line)
+				b.WriteString("\n")
+				if n.Note != "" {
+					b.WriteString(fmt.Sprintf("  - Note: %s\n", n.Note))
+				}
+			}
+			notesMarkdown = strings.TrimSpace(b.String())
+		}
 	}
 
 	src := fmt.Sprintf(`Hi,
 A new KubeDB sales QA result has been submitted with the following details:
 
+## Prospect
+- Name: %s
+- Email: %s
+- Company: %s
+- Title: %s
+- Phone: %s
+- Country: %s
+- Address: %s
+- Notes: %s
+
+## Qualification Summary
+- Distro: %s (%s)
+- Verdict: %s
+- Verdict Text: %s
+- Hot: %d
+- Warm: %d
+- Cold: %d
+
+## Notes
 %s
 
 Regards,
 KubeDB Sales QA System
-`, string(data))
+`,
+		info.ContactName,
+		info.ContactEmail,
+		info.ContactCompany,
+		info.ContactTitle,
+		info.ContactPhone,
+		info.ContactCountry,
+		info.ContactAddress,
+		info.ContactNotes,
+		info.DistroLabel,
+		info.Distro,
+		info.Verdict,
+		info.VerdictText,
+		info.HotCount,
+		info.WarmCount,
+		info.ColdCount,
+		notesMarkdown,
+	)
 	return mailer.Mailer{
 		Sender:          MailSales,
 		BCC:             "",


### PR DESCRIPTION
## Summary
- update pkg/server/mail_kubedb_inquiry.go to send structured markdown body instead of YAML dump
- update pkg/server/mail_deal_registration.go to send structured markdown body instead of YAML dump
- update pkg/server/mail_kubedb_sales_qa.go to render notesJson as markdown bullets

## Validation
- gofmt on modified files
- go test -mod=vendor ./pkg/server -run TestFormatRFC822Email
